### PR TITLE
build: revert dependency submission on every build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,5 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v3
         with:
-          cache-read-only: true
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - run: make ci-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
+      contents: read
       packages: read
     env:
       ORG_GRADLE_PROJECT_ghUsername: ${{ secrets.GITHUB_ACTOR }}
@@ -20,6 +20,6 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@v3
         with:
+          cache-read-only: true
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - run: make ci-build
-      - uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
- **Revert "build: submit dependencies to github (#85)"**
- **build: cache still shouldn't be readonly**
