### PR TITLE
chore: Update Renovate workflow to remove schedule

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,10 +4,6 @@
 
 name: renovate
 on:
-  schedule:
-    # Run every day at 02:00 UTC (before update-java at 03:00)
-    - cron: "0 2 * * *"
-    - cron: "*/5 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removed scheduled cron jobs from Renovate workflow.