### PR TITLE
chore(build): remove prettier-plugin-sh and update gradle.properties for

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -6,11 +6,12 @@
 module.exports = {
   printWidth: 120,
   xmlWhitespaceSensitivity: "ignore",
+  keySeparator: "=",
   plugins: [
     require.resolve("@prettier/plugin-xml"),
     require.resolve("prettier-plugin-properties"),
     require.resolve("prettier-plugin-java"),
     require.resolve("prettier-plugin-toml"),
-    require.resolve("prettier-plugin-sh"),
+    // require.resolve("prettier-plugin-sh"),
   ],
 };

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,9 @@
-# SPDX-FileCopyrightText: Copyright © 2024 - 2025 Caleb Cushing
+# SPDX-FileCopyrightText: Copyright © 2024-2026 Caleb Cushing
 #
 # SPDX-License-Identifier: CC0-1.0
 
-org.gradle.caching = true
-org.gradle.parallel = true
-org.gradle.configuration-cache = true
-org.gradle.configuration-cache.parallel = true
-dependency.analysis.print.build.health = true
-org.gradle.jvmargs = \
-  -XX:+UseZGC \
-  -XX:+ZGenerational \
-  -XX:+UseStringDeduplication \
-  -Xmx2g \
-  -XX:MaxMetaspaceSize=768m \
-  -Dfile.encoding=UTF-8 \
-  -Duser.country=US \
-  -Duser.language=en
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+dependency.analysis.print.build.health=true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "prettier": "^3.6.2",
     "prettier-plugin-java": "^2.7.5",
     "prettier-plugin-properties": "^0.3.0",
-    "prettier-plugin-sh": "^0.18.0",
     "prettier-plugin-toml": "^2.0.6",
     "rimraf": "^6.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,13 +141,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reteps/dockerfmt@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "@reteps/dockerfmt@npm:0.3.6"
-  checksum: 10c0/b6ca467ba97ea49071c44d0fbecf131fc8045165e950d0d01372c1834000c58d53f62bff42f09b851f7a9d91899047f071cd8fe57e1fc88fc27e2a3d2bdb214d
-  languageName: node
-  linkType: hard
-
 "@taplo/core@npm:^0.2.0":
   version: 0.2.0
   resolution: "@taplo/core@npm:0.2.0"
@@ -412,7 +405,6 @@ __metadata:
     prettier: "npm:^3.6.2"
     prettier-plugin-java: "npm:^2.7.5"
     prettier-plugin-properties: "npm:^0.3.0"
-    prettier-plugin-sh: "npm:^0.18.0"
     prettier-plugin-toml: "npm:^2.0.6"
     rimraf: "npm:^6.1.2"
   languageName: unknown
@@ -587,18 +579,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-sh@npm:^0.18.0":
-  version: 0.18.0
-  resolution: "prettier-plugin-sh@npm:0.18.0"
-  dependencies:
-    "@reteps/dockerfmt": "npm:^0.3.6"
-    sh-syntax: "npm:^0.5.8"
-  peerDependencies:
-    prettier: ^3.6.0
-  checksum: 10c0/d8946440abaab1c0f32cee270e0ad285e1f4bba0008aff7c55a9a1c8639032aa8b397aef8f8387a5b88c3f4fb657f1d4d1ab7ae6a1f5c4599875080fb951b9b1
-  languageName: node
-  linkType: hard
-
 "prettier-plugin-toml@npm:^2.0.6":
   version: 2.0.6
   resolution: "prettier-plugin-toml@npm:2.0.6"
@@ -659,15 +639,6 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 10c0/4a56537850102e20ba5d5eb49f366b4b7b2435389734b4b8480cf0e0eb0f6f5d0c44120a171aeb0d8f9ab40312a10d2262f3f50acbad803e32caef61b6cf86fc
-  languageName: node
-  linkType: hard
-
-"sh-syntax@npm:^0.5.8":
-  version: 0.5.8
-  resolution: "sh-syntax@npm:0.5.8"
-  dependencies:
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/2d2609fc8760ef97175c852be26ee3eeb196078c5aec282c8b96a59ee362be4f470d3e0df4e372da6c7a7b44ccc42910cbdcb0915271b3cb6a6212d00dde116f
   languageName: node
   linkType: hard
 
@@ -749,13 +720,6 @@ __metadata:
   version: 1.0.4
   resolution: "tinyexec@npm:1.0.4"
   checksum: 10c0/d4a5bbcf6bdb23527a4b74c4aa566f41432167112fe76f420ec7e3a90a3ecfd3a7d944383e2719fc3987b69400f7b928daf08700d145fb527c2e80ec01e198bd
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.8.1":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Remove prettier-plugin-sh due to maintenance concerns and update build
configuration files.

- Rename .prettierrc.js to .prettierrc.cjs for CommonJS compatibility
- Add keySeparator: "=" to prettier-plugin-properties config
- Remove prettier-plugin-sh and its dependencies (sh-syntax, dockerfmt)
- Reformat gradle.properties to use "=" separator without spaces
- Remove custom JVM args from gradle.properties
- Update copyright year to 2024-2026 in gradle.properties header
