### PR TITLE
chore(renovate): simplify gradle update rules by removing major update schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,19 +26,8 @@
     // This effectively ignores libs.versions.toml and build.gradle.kts for non-major updates.
     {
       matchManagers: ["gradle", "gradle-wrapper"],
-      matchUpdateTypes: ["minor", "patch", "pin", "digest"],
+      matchUpdateTypes: ["major", "minor", "patch", "pin", "digest"],
       enabled: false,
-    },
-    // 2. Goal A: Notify on Major updates (excluding wrapper, as requested)
-    // This will re-enable Major updates for TOML/Build files so you get a PR.
-    {
-      // remember to sync with update-java
-      // Runs during the 04:00 UTC hour daily (scheduled after update-java at 03:00)
-      schedule: ["* 4 * * *"],
-      matchManagers: ["gradle"],
-      // Open PRs for MAJOR updates only; minor/patch are handled elsewhere
-      matchUpdateTypes: ["major"],
-      automerge: false,
     },
     // 3. Goal B: Settings Exception (Develocity & Plugins)
     // Re-enable everything for settings files and automerge them.


### PR DESCRIPTION
Remove the separate scheduled rule for major Gradle updates and instead
include "major" in the disabled update types for Gradle dependencies.

This simplifies the Renovate configuration by consolidating all Gradle
update types (major, minor, patch, pin, digest) into a single disabled
rule, eliminating the need for a separate scheduled major update rule.